### PR TITLE
Remove offchain lookup revert

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,22 @@
 
 IPFS2.eth ("IPFS-To-ETH") is a proof-of-concept IPFS gateway-like framework with an ENS CCIP-Read Resolver wrapped in a `base32` and `base36` decoder. IPFS2.eth is capable of resolving IPFS and IPNS (and IPLD) contenthashes as subdomains `*.ipfs2.eth` when queried as ENS subdomain or via public ENS gateway services such as `*.IPFS2.eth.limo`  
 
-> IPFS : https://bafybeiftyo7xm6ktvsmijtwyzcqavotjybnmsiqfxx3fawxvpr666r6z64.ipfs2.eth.limo 
-> 
-> IPNS : https://k51qzi5uqu5dkgt2xdmfcyh6058cl8fa6tfnj06u6vdf510260imor3yak48fv.ipfs2.eth.limo
-> 
-> IPLD : https://bafyreie2nochynilsdmcyqpxid7d2dzdle4dbptvep65kujtg2uywm7jre.ipfs2.eth.limo
+## Supported Subdomain Formats :
+### IPFS (base32) : `b<base32>.ipfs2.eth`
+> https://bafybeiftyo7xm6ktvsmijtwyzcqavotjybnmsiqfxx3fawxvpr666r6z64.ipfs2.eth.limo
 
-IPFS2.eth can be used
+### IPNS (base36) : `k<base36>.ipfs2.eth`
+> https://k51qzi5uqu5dkgt2xdmfcyh6058cl8fa6tfnj06u6vdf510260imor3yak48fv.ipfs2.eth.limo
 
-- to fetch the ENS contenthash as the parent domain's subdomain, and
-- to fetch the RFC-8615 compliant ENS records stored at that contenthash, if requested.
+### IPLD(base32/dag-cbor) : 
+https://bafyreie2nochynilsdmcyqpxid7d2dzdle4dbptvep65kujtg2uywm7jre.ipfs2.eth.limo
+> 
+### IPFS/IPNS (Base16/sub domains) : `f<prefix>.<bytes16>.<bytes16>.ipfs2.eth`
+> https://f0172002408011220.32a1a9c61c6d14bbde2bca0be1b28c28.6be6b484fc804170e2d632b07f0c0b0d.ipfs2.eth.limo
+
+### ENS Contenthash (Base16/sub domains) : `<prefix>.<bytes16>.<bytes16>.ipfs2.eth`
+
+>https://e5010172002408011220.32a1a9c61c6d14bbde2bca0be1b28c28.6be6b484fc804170e2d632b07f0c0b0d.ipfs2.eth.limo
 
 Several centralised providers offer public gateways for IPFS/IPNS resolution such as `https://dweb.link` and `https://ipfs.io`. IPFS2 is a service similar to these public IPFS gateways but it uses an ENS CCIP-Read Resolver and public ENS gateways (`eth.limo`, `eth.link` etc). IPFS2 uses `eth.limo` as its default CCIP gateway to read specific ENS records and is designed to fallback to secondary gateways.
 
@@ -37,37 +43,15 @@ IPFS2 architecture is as follows:
 
 ![](https://raw.githubusercontent.com/namesys-eth/ipfs2-resources/main/graphics/ipfs2.png)
 
-## Query Syntax
 
 ### Resolve `contenthash`
 
 Resolution of `<CIDv1-base32>.ipfs2.eth` will decode and resolve `<CIDv1-base32>` via CCIP as ABI-encoded contenthash. This functionality supports both IPNS and IPFS (and IPLD) contenthashes in `base32` format.
 
-### Resolving ENS Records
+~~### Resolving ENS Records~~
 
-IPFS2 Resolver also supports ENS-specific features such as querying ENS records associated with the (sub)domain. We use [RFC-8615](https://www.rfc-editor.org/rfc/rfc8615) `.well-known` directory format to implement this. The query syntax then reads:
+~~IPFS2.eth doesn't support records management for ipfs/IPNS subdomains, we've no owner records for subs to validate & plaintext records are not good for security reasons..~~
 
-```
-https://<hash>.ipfs2.eth.*/.well-known/<data>.json
-```
-
-#### Some Examples
-
-1. (Sub)domain's ENS avatar record is stored as `<CIDv1-base32>.ipfs2.eth.*/.well-known/avatar.json` in format
-
-```
-{
-  "data": "0x_abi_encoded_avatar_string"
-}
-```
-
-2. (Sub)domain's ETH address record is stored as `<CIDv1-base32>.ipfs2.eth.*/.well-known/addr-60.json` in format
-
-```
-{
-  "data": "0x_abi_encoded_address"
-}
-```
 
 #### Using Ethers JS, resolver contract converts ipfs/ipns hash subdomain as contenthash  
 

--- a/src/Interface.sol
+++ b/src/Interface.sol
@@ -1,72 +1,22 @@
-//SPDX-License-Identifier: WTFPL v6.9
-pragma solidity >=0.8.4;
+//SPDX-License-Identifier: WTFPL.ETH
+pragma solidity >0.8.0 <0.9.0;
 
 interface iERC165 {
     function supportsInterface(bytes4 interfaceID) external view returns (bool);
 }
 
-interface iENS {
-    function owner(bytes32 node) external view returns (address);
-    function resolver(bytes32 node) external view returns (address);
-    function ttl(bytes32 node) external view returns (uint64);
-    function recordExists(bytes32 node) external view returns (bool);
-    //function isApprovedForAll(address owner, address operator) external view returns (bool);
-}
-
 interface iCCIP {
     function resolve(bytes memory name, bytes memory data) external view returns (bytes memory);
-
-    function __callback(bytes calldata response, bytes calldata extraData)
-        external
-        view
-        returns (bytes memory result);
-
-    //function signedBy(bytes32 digest, bytes calldata signature) external pure returns (address _addr);
-}
-
-interface iIPNS {
-    function setContenthash(bytes32 node, bytes calldata _ch) external view returns (bytes memory);
 }
 
 interface iResolver {
     function contenthash(bytes32 node) external view returns (bytes memory);
-
-    function addr(bytes32 node) external view returns (address payable);
-
-    function pubkey(bytes32 node) external view returns (bytes32 x, bytes32 y);
-
-    function text(bytes32 node, string calldata key) external view returns (string memory value);
-
-    function name(bytes32 node) external view returns (string memory);
-
-    function ABI(bytes32 node, uint256 contentTypes) external view returns (uint256, bytes memory);
-
-    function interfaceImplementer(bytes32 node, bytes4 interfaceID) external view returns (address);
-
-    function zonehash(bytes32 node) external view returns (bytes memory);
-
-    function dnsRecord(bytes32 node, bytes32 name, uint16 resource) external view returns (bytes memory);
-
-    //function recordVersions(bytes32 node) external view returns (uint64);
-
-    /// @dev : set contenthash
-    function setContenthash(bytes32 node, bytes calldata hash) external;
-}
-
-interface iOverloadResolver {
-    function addr(bytes32 node, uint256 coinType) external view returns (bytes memory);
+    function setContenthash(bytes32 node, bytes calldata _ch) external view returns (bytes memory);
 }
 
 interface iToken {
-    function ownerOf(uint256 id) external view returns (address);
     function transferFrom(address from, address to, uint256 bal) external;
     function safeTransferFrom(address from, address to, uint256 bal) external;
-    function isApprovedForAll(address _owner, address _operator) external view returns (bool);
-
-    event Approval(address indexed _owner, address indexed _approved, uint256 indexed _tokenId);
-    event ApprovalForAll(address indexed _owner, address indexed _operator, bool _approved);
-
-    function setApprovalForAll(address _operator, bool _approved) external;
 }
 
 interface iERC173 {

--- a/test/IPFS2ETH.t.sol
+++ b/test/IPFS2ETH.t.sol
@@ -11,10 +11,12 @@ contract IPFS2Test is Test {
 
     IPFS2ETH ipfs2eth;
     Utils utils;
+    CCIPTest xccip;
 
     constructor() {
         ipfs2eth = new IPFS2ETH();
         utils = new Utils();
+        xccip = new CCIPTest();
     }
 
     function testSetup() public {
@@ -23,37 +25,21 @@ contract IPFS2Test is Test {
         _test[1] = "eth";
         (bytes32 _namehash, bytes memory _name) = utils.Encode(_test);
         assertEq(_name, bytes.concat(bytes1(uint8(5)), "ipfs2", bytes1(uint8(3)), "eth", bytes1(0)));
-        //assertEq(_name, abi.encodePacked(ipfs2eth.suffixCheck()));
         assertEq(
             _namehash,
             keccak256(abi.encodePacked(keccak256(abi.encodePacked(bytes32(0), keccak256("eth"))), keccak256("ipfs2")))
         );
     }
 
-    function testHomeContenthash() public {
+    function testDefaultContenthash() public {
         bytes[] memory _name = new bytes[](2);
         _name[0] = "ipfs2";
         _name[1] = "eth";
         (bytes32 _namehash, bytes memory _encoded) = utils.Encode(_name);
         bytes memory _request = abi.encodePacked(iResolver.contenthash.selector, _namehash);
-        string[] memory _urls = new string[](2);
-        _urls[0] = 'data:application/json,{"data":"{data}"}';
-        _urls[1] = 'data:text/plain,{"data":"{data}"}';
-        bytes memory _data = ipfs2eth.HomeContenthash();
-        bytes32 _checkHash =
-            keccak256(abi.encodePacked(blockhash(block.number - 1), address(ipfs2eth), address(this), _data));
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IPFS2ETH.OffchainLookup.selector,
-                address(ipfs2eth),
-                _urls,
-                _data,
-                IPFS2ETH.__callback.selector,
-                abi.encode(block.number - 1, _checkHash)
-            )
-        );
-        ipfs2eth.resolve(_encoded, _request);
-        assertEq(abi.encode(_data), ipfs2eth.__callback(_data, abi.encode(block.number - 1, _checkHash)));
+        ipfs2eth.setCCIP2Contract(address(xccip));
+        bytes memory _data = ipfs2eth.DefaultContenthash();
+        assertEq(abi.encode(_data), ipfs2eth.resolve(_encoded, _request));
     }
 
     function testResolveBase32() public {
@@ -64,26 +50,7 @@ contract IPFS2Test is Test {
         (bytes32 _namehash, bytes memory _encoded) = utils.Encode(_name);
         bytes memory _data = ipfs2eth.decodeBase32(bytes("afybeieexfyfk3blzpi7g7j3aaogyvlg7qhopr7ru5x5v3nxrlx5zihnaa"));
         bytes memory _request = abi.encodePacked(iResolver.contenthash.selector, _namehash);
-        string[] memory _urls = new string[](2);
-        _urls[0] = 'data:application/json,{"data":"{data}"}';
-        _urls[1] = 'data:text/plain,{"data":"{data}"}';
-        bytes32 _checkHash =
-            keccak256(abi.encodePacked(blockhash(block.number - 1), address(ipfs2eth), address(this), _data));
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IPFS2ETH.OffchainLookup.selector,
-                address(ipfs2eth),
-                _urls,
-                _data,
-                IPFS2ETH.__callback.selector,
-                abi.encode(block.number - 1, _checkHash)
-            )
-        );
-        ipfs2eth.resolve(_encoded, _request);
-        assertEq(
-            abi.encode(abi.encodePacked(bytes2(0xe301), _data)),
-            ipfs2eth.__callback(_data, abi.encode(block.number - 1, _checkHash))
-        );
+        assertEq(abi.encode(abi.encodePacked(bytes2(0xe301), _data)), ipfs2eth.resolve(_encoded, _request));
     }
 
     function testResolveBase36() public {
@@ -95,26 +62,8 @@ contract IPFS2Test is Test {
         bytes memory _data =
             ipfs2eth.decodeBase36(bytes("51qzi5uqu5dhg0onhctxbxl0cxnxsdsg5hstxn0x97gxb36tmwjluwq0l0aod"));
         bytes memory _request = abi.encodePacked(iResolver.contenthash.selector, _namehash);
-        string[] memory _urls = new string[](2);
-        _urls[0] = 'data:application/json,{"data":"{data}"}';
-        _urls[1] = 'data:text/plain,{"data":"{data}"}';
-        bytes32 _checkHash =
-            keccak256(abi.encodePacked(blockhash(block.number - 1), address(ipfs2eth), address(this), _data));
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IPFS2ETH.OffchainLookup.selector,
-                address(ipfs2eth),
-                _urls,
-                _data,
-                IPFS2ETH.__callback.selector,
-                abi.encode(block.number - 1, _checkHash)
-            )
-        );
-        ipfs2eth.resolve(_encoded, _request);
-        assertEq(
-            abi.encode(abi.encodePacked(bytes2(0xe501), _data)),
-            ipfs2eth.__callback(_data, abi.encode(block.number - 1, _checkHash))
-        );
+
+        assertEq(abi.encode(abi.encodePacked(bytes2(0xe501), _data)), ipfs2eth.resolve(_encoded, _request));
     }
 
     function testResolveHexSubsA() public {
@@ -129,26 +78,8 @@ contract IPFS2Test is Test {
             bytes("017200240801122032a1a9c61c6d14bbde2bca0be1b28c286be6b484fc804170e2d632b07f0c0b0d")
         );
         bytes memory _request = abi.encodePacked(iResolver.contenthash.selector, _namehash);
-        string[] memory _urls = new string[](2);
-        _urls[0] = 'data:application/json,{"data":"{data}"}';
-        _urls[1] = 'data:text/plain,{"data":"{data}"}';
-        bytes32 _checkHash =
-            keccak256(abi.encodePacked(blockhash(block.number - 1), address(ipfs2eth), address(this), _data));
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IPFS2ETH.OffchainLookup.selector,
-                address(ipfs2eth),
-                _urls,
-                _data,
-                IPFS2ETH.__callback.selector,
-                abi.encode(block.number - 1, _checkHash)
-            )
-        );
-        ipfs2eth.resolve(_encoded, _request);
-        assertEq(
-            abi.encode(abi.encodePacked(bytes2(0xe501), _data)),
-            ipfs2eth.__callback(_data, abi.encode(block.number - 1, _checkHash))
-        );
+
+        assertEq(abi.encode(abi.encodePacked(bytes2(0xe501), _data)), ipfs2eth.resolve(_encoded, _request));
     }
 
     function testResolveHexSubsB() public {
@@ -163,24 +94,13 @@ contract IPFS2Test is Test {
             bytes("e501017200240801122032a1a9c61c6d14bbde2bca0be1b28c286be6b484fc804170e2d632b07f0c0b0d")
         );
         bytes memory _request = abi.encodePacked(iResolver.contenthash.selector, _namehash);
-        string[] memory _urls = new string[](2);
-        _urls[0] = 'data:application/json,{"data":"{data}"}';
-        _urls[1] = 'data:text/plain,{"data":"{data}"}';
-        bytes32 _checkHash =
-            keccak256(abi.encodePacked(blockhash(block.number - 1), address(ipfs2eth), address(this), _data));
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IPFS2ETH.OffchainLookup.selector,
-                address(ipfs2eth),
-                _urls,
-                _data,
-                IPFS2ETH.__callback.selector,
-                abi.encode(block.number - 1, _checkHash)
-            )
-        );
-        ipfs2eth.resolve(_encoded, _request);
-        assertEq(
-            abi.encode(abi.encodePacked(_data)), ipfs2eth.__callback(_data, abi.encode(block.number - 1, _checkHash))
-        );
+        assertEq(abi.encode(abi.encodePacked(_data)), ipfs2eth.resolve(_encoded, _request));
+    }
+}
+
+contract CCIPTest {
+    function resolve(bytes calldata, bytes calldata) external view returns (bytes memory) {
+        this;
+        return abi.encode(hex"e50101720024080112206377fe7e59802cc7160886ef388d2eda7a1a6fbd48156153975e443ae8d00438");
     }
 }


### PR DESCRIPTION
Looks like ethers.js v6 fixed bug handling direct return from resolve function, 
so we no longer need complicated offchain lookup revert for this basic resolver.

IPFS2.eth no longer supports ENS records in *.ipfs2.eth as it's too complicated to implement without ownership records of such subs. ipfs2.eth's own records are redirected to ccip2.eth's resolve, & it reverts for all other non-contenthash requests for *.ipfs2.eth.

ready for testnet++